### PR TITLE
Proposing Manifests-Complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ The following fields make up a BagIt profile. Each field is a top-level JSON key
 	
 4. `Manifests-Complete`: `true`|`false`
 
-        If `true`, then every manifest listed under `Manifests-Required` must contain a complete list
-        of the payload files. 
-        
-        Default: `false`
+	If `true`, then every manifest as listed under `Manifests-Required` 
+	must contain a complete list of all payload files. 
+	If `Manifests-Required` is not provided, then this applies
+	to *all* payload manifests.
+	
+	Default: `false`
 
 4. `Allow-Fetch.txt`: `true`|`false`
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ BagIt Profiles Specification
 
 Status of this specification
 ---
-Current version: 1.0 (2013-05-19). Maintained by Mark Jordan and Nick Ruest. 
+Current version: 1.1 (2015-08-06). Maintained by Mark Jordan and Nick Ruest. 
 
 Original draft created by members of the Access 2012 Hackfest group: Meghan Currie, Krista Godfrey, Mark Jordan, Nick Ruest, William Wueppelmann, and Dan Chudnov. 
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ The following fields make up a BagIt profile. Each field is a top-level JSON key
 	Each manifest type in LIST is required. The list contains the type of manifest, not
 	the complete filename, e.g. `["sha1", "md5"]`.
 	
+4. `Manifests-Complete`: `true`|`false`
+
+        If `true`, then every manifest listed under `Manifests-Required` must contain a complete list
+        of the payload files. 
+        
+        Default: `false`
+
 4. `Allow-Fetch.txt`: `true`|`false`
 
 	A fetch.txt file is allowed within the bag. Default: `true`


### PR DESCRIPTION
See jkunze/bagitspec#6 which says that manifests are not necessarily individually complete.

I think a profile should be able to restrict this so that a consumer can rely on a fixed list of manifests to be known to be complete lists of the whole payload.

A similar `Tag-Manifests-Complete` property could be even more useful as the BagIt spec do not require all tagfiles to be listed at all, but would have to specify which tagfiles are excluded (e.g. the tag manifest itself)
