### PR TITLE
Add ReSPec warning w/r/t overrideCopyright

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,11 +56,11 @@
             }
           ]
         }],
-        overrideCopyright: "<p class='copyright'>This document is licensed under a <a class='subfoot' href='https://creativecommons.org/publicdomain/zero/1.0/' rel='license'>CC0 1.0 Universal (CC0 1.0) Public Domain Dedication</a>.</p>"
       };
     </script>
   </head>
   <body>
+    <p class='copyright'>This document is licensed under a <a class='subfoot' href='https://creativecommons.org/publicdomain/zero/1.0/' rel='license'>CC0 1.0 Universal (CC0 1.0) Public Domain Dedication</a>.</p>
     <h1>Introduction</h1>
     <section id='abstract'>
       <p>


### PR DESCRIPTION
- "The overrideCopyright configuration option is deprecated. Please use
<p class="copyright"> instead."

Take care of this: 
![Screenshot from 2020-01-23 10-10-49](https://user-images.githubusercontent.com/218561/72996422-adfcc980-3dc8-11ea-9fab-790de56344d2.png)
