### PR TITLE
ReSpec syntax updates for #33.

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,15 +28,20 @@
           mailto: "john.scancella@gmail.com"
         }
         ],
+        latestVersion: null,
         edDraftURI: "https://bagit-profiles.github.io/bagit-profiles-specification/",
         github: "https://github.com/bagit-profiles/bagit-profiles-specification",
-        wgPublicList: "https://groups.google.com/forum/#!forum/fedora-community",
+        wgPublicList: "https://groups.google.com/g/digital-curation",
         otherLinks: [{
           key: "Previous version",
           data: [
               {
                 value: "1.2.0",
-                href: "https://github.com/bagit-profiles/bagit-profiles-specification/commit/c5ecfa8afe0e3de11eccb68f3f1e9d56197a1578"
+                href: "https://github.com/bagit-profiles/bagit-profiles-specification/blob/c5ecfa8afe0e3de11eccb68f3f1e9d56197a1578/README.md"
+              },
+              {
+                value: "1.1.0",
+                href: "https://github.com/bagit-profiles/bagit-profiles-specification/blob/abaedfc3cec2bfaf20cd19d96893085a83ca6f3d/README.md"
               }
             ]
         },{


### PR DESCRIPTION
- Set latestVersion to null since we don't have a w3c version
  - https://respec.org/docs/#w3c
- Set the public mailing list to digital curation (fcrepo was copypasta)
- Point the previous version correctly at the previous version
- Resolves #33